### PR TITLE
allow to use a key named "key" in configuration

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -1,6 +1,8 @@
 development:
   proxy:
     port: 3000
+  some_api:
+    key: secret
   hostname: example.com
   secret_key: <%= ENV["SECRET_KEY"] %>
   array_key:

--- a/lib/app_konfig/config.rb
+++ b/lib/app_konfig/config.rb
@@ -9,6 +9,7 @@ module AppKonfig
       public: './config/config.yml',
       secret: './config/secrets.yml',
     }
+    undef_method :key
 
     def initialize
       super

--- a/spec/app_konfig_spec.rb
+++ b/spec/app_konfig_spec.rb
@@ -26,6 +26,10 @@ RSpec.describe AppKonfig::Config do
     expect(subject.array_key).to eq(['first_new', 'second_new', 'third_new'])
   end
 
+  it 'allows to use a key named "key" in configuration' do
+    expect(subject.some_api.key).to eq('secret')
+  end
+
   it 'allows to embed ruby inside a config file' do
     allow(ENV).to receive(:[]).with('SECRET_KEY').and_return('value_from_env')
     expect(subject.secret_key).to eq('value_from_env')


### PR DESCRIPTION
currently, it's not possible to use a configuration like this:

```yml
foo:
  key: 'baz'
```

because you'll get something like:

```
> AppConfig.foo.key
ArgumentError: wrong number of arguments (0 for 1)
```

I've removed `key` method from the `Config` class, it seems it doesn't break anything. 