### PR TITLE
Make the AppKonfig gem compatible with a previous version

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,3 +1,9 @@
+1.0.0
+
+- Add a getter method to solve some conflicts with configuration keys (@mtczerwinski)
+- Add test (@mtczerwinski)
+- Add information into readme (@mtczerwinski)
+
 0.1.0
 
 - Lessen rails dependency - minimal version is now 3.0 (@nekath)

--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,3 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in app_konfig.gemspec
 gemspec
-
-gem 'pry'

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,5 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in app_konfig.gemspec
 gemspec
+
+gem 'pry'

--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ AppConfig.value
 AppConfig.proxy.ip
 AppConfig.secret_key
 ```
+or
+```ruby
+AppConfig.get('value')
+AppConfig.get('proxy.ip')
+AppConfig.get('secret_key')
+```
 
 ## Contributing
 

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -1,6 +1,15 @@
 production:
+  key: "key"
+  keys: 123456789
   hostname: 'production.example.com'
   array_key:
     - first_new
     - second_new
     - third_new
+  other:
+    values:
+      - first_old
+      - second_old
+      - third_old
+  values: 'James Bond'
+  value: ''

--- a/lib/app_konfig/config.rb
+++ b/lib/app_konfig/config.rb
@@ -15,6 +15,11 @@ module AppKonfig
       deep_merge!(pub_config).deep_merge!(sec_config)
     end
 
+    def self.get(args)
+      self.new
+      args.split('.').inject(self) { |hash, arg| hash.fetch(arg) }
+    end
+
     def method_missing(key)
       key = key.to_s
       return self[key] unless self[key].is_a?(Hash)

--- a/lib/app_konfig/config.rb
+++ b/lib/app_konfig/config.rb
@@ -15,12 +15,11 @@ module AppKonfig
     def initialize
       super
       deep_merge!(pub_config).deep_merge!(sec_config)
-      self
     end
 
     def get(args)
         args.split('.').inject(self) { |hash, arg| hash.fetch(arg) }
-      rescue
+      rescue KeyError
         raise AppKonfig::ConfigurationKeyNotFound.new("configuration key not found")
     end
 

--- a/lib/app_konfig/config.rb
+++ b/lib/app_konfig/config.rb
@@ -3,6 +3,8 @@ require 'yaml'
 require 'erb'
 
 module AppKonfig
+  class ConfigurationKeyNotFound < Exception ; end
+
   class Config < Hash
     DEFAULT_ENV = 'development'
     CONFIG_PATH = {
@@ -13,11 +15,13 @@ module AppKonfig
     def initialize
       super
       deep_merge!(pub_config).deep_merge!(sec_config)
+      self
     end
 
-    def self.get(args)
-      self.new
-      args.split('.').inject(self) { |hash, arg| hash.fetch(arg) }
+    def get(args)
+        args.split('.').inject(self) { |hash, arg| hash.fetch(arg) }
+      rescue
+        raise AppKonfig::ConfigurationKeyNotFound.new("configuration key not found")
     end
 
     def method_missing(key)

--- a/lib/app_konfig/version.rb
+++ b/lib/app_konfig/version.rb
@@ -1,3 +1,3 @@
 module AppKonfig
-  VERSION = '0.1.0'.freeze
+  VERSION = '1.0.0'.freeze
 end

--- a/spec/app_konfig_spec.rb
+++ b/spec/app_konfig_spec.rb
@@ -2,34 +2,82 @@ require 'spec_helper'
 require 'app_konfig/config'
 
 RSpec.describe AppKonfig::Config do
-  it 'is a Hash' do
-    expect(subject).to be_a(Hash)
+  context '#get' do
+    it 'loads config based on RAILS_ENV' do
+      allow(ENV).to receive(:fetch).and_return('test')
+      expect(subject.get('hostname')).to eq('test.example.com')
+    end
+
+    it 'uses development config by default' do
+      expect(described_class::DEFAULT_ENV).to eq('development')
+      expect(subject.get('hostname')).to eq('example.com')
+    end
+
+    it 'handles nested keys' do
+      expect(subject.get('proxy.port')).to eq(3000)
+    end
+
+    it 'merges config from secrets file' do
+      allow(ENV).to receive(:fetch).and_return('production')
+      expect(subject.get('hostname')).to eq('production.example.com')
+      expect(subject.get('array_key')).to eq(['first_new', 'second_new', 'third_new'])
+    end
+
+    it 'allows to use a configuration names the same as methods from the Hash class' do
+      allow(ENV).to receive(:fetch).and_return('production')
+      expect(subject.get('keys')).to eq(123456789)
+      expect(subject.get('key')).to eq("key")
+      expect(subject.get('other.values')).to eq(["first_old", "second_old", "third_old"])
+      expect(subject.get('values')).to eq("James Bond")
+      expect(subject.get('value')).to eq("")
+    end
+
+    it 'raises exception when a configuration key was not found' do
+      allow(ENV).to receive(:fetch).and_return('production')
+      expect { subject.get('test.test3.test2.test1') }.to raise_error(AppKonfig::ConfigurationKeyNotFound)
+    end
+
+    it 'allows to embed ruby inside a config file' do
+      allow(ENV).to receive(:[]).with('SECRET_KEY').and_return('value_from_env')
+      expect(subject.get('secret_key')).to eq('value_from_env')
+    end
   end
 
-  it 'loads config based on RAILS_ENV' do
-    allow(ENV).to receive(:fetch).and_return('test')
-    expect(subject.hostname).to eq('test.example.com')
+  context 'a chain method invoking' do
+    it 'loads config based on RAILS_ENV' do
+      allow(ENV).to receive(:fetch).and_return('test')
+      expect(subject.hostname).to eq('test.example.com')
+    end
+
+    it 'uses development config by default' do
+      expect(described_class::DEFAULT_ENV).to eq('development')
+      expect(subject.hostname).to eq('example.com')
+    end
+
+    it 'handles nested keys' do
+      expect(subject.proxy.port).to eq(3000)
+    end
+
+    it 'merges config from secrets file' do
+      allow(ENV).to receive(:fetch).and_return('production')
+      expect(subject.hostname).to eq('production.example.com')
+      expect(subject.array_key).to eq(['first_new', 'second_new', 'third_new'])
+    end
+
+    it 'allows to use a configuration names the same as methods from the Hash class' do
+      allow(ENV).to receive(:fetch).and_return('production')
+      expect(subject.keys).to eq ["hostname", "key", "keys", "array_key", "other", "values", "value"]
+      expect(subject.other.values).to eq([["first_old", "second_old", "third_old"]])
+      expect(subject.values).to eq ["production.example.com", "key", 123456789, ["first_new", "second_new", "third_new"], {"values"=>["first_old", "second_old", "third_old"]}, "James Bond", ""]
+      expect(subject.value).to eq("")
+    end
+
+    it 'allows to embed ruby inside a config file' do
+      allow(ENV).to receive(:[]).with('SECRET_KEY').and_return('value_from_env')
+      expect(subject.secret_key).to eq('value_from_env')
+    end
   end
 
-  it 'uses development config by default' do
-    expect(described_class::DEFAULT_ENV).to eq('development')
-    expect(subject.hostname).to eq('example.com')
-  end
-
-  it 'handles nested keys' do
-    expect(subject.proxy.port).to eq(3000)
-  end
-
-  it 'merges config from secrets file' do
-    allow(ENV).to receive(:fetch).and_return('production')
-    expect(subject.hostname).to eq('production.example.com')
-    expect(subject.array_key).to eq(['first_new', 'second_new', 'third_new'])
-  end
-
-  it 'allows to embed ruby inside a config file' do
-    allow(ENV).to receive(:[]).with('SECRET_KEY').and_return('value_from_env')
-    expect(subject.secret_key).to eq('value_from_env')
-  end
 
   context 'when secrets file is not found' do
     it 'fails silently' do


### PR DESCRIPTION
You can use the AppKonfig gem in two ways, for instance:
```ruby
>  AppConfig.proxy
 => {"ip"=>"127.0.0.1", "port"=>8080}
> AppConfig.proxy.ip
 => "127.0.0.1"
```
by a old way, new one:
```ruby
AppConfig.get('proxy.ip')
 => "127.0.0.1"
```
Worth to mention is a fact that `get` method allows a developer to omit a problem related to the Hash class:
```ruby
> AppConfig
 => {"value"=>{"key"=>1}, "proxy"=>{"ip"=>"127.0.0.1", "port"=>8080}, "secret_key"=>"DEV_TOKEN", "secret_key_base"=>"cd8eacbd930c2c35f1627bcd8536c70a4e3fdde458673015ba96fb485398a485e9af3414e02abc702a1df6f85731d623e1f1a23725c4f2d34c0b919efb3f4f7f"}
> AppConfig.value.key
ArgumentError: wrong number of arguments (given 0, expected 1)
```
but using `get` method, a developer receives:
```ruby
> AppConfig.get('value.key')
 => 1
```
