### PR TITLE
Not require config.yml file

### DIFF
--- a/lib/app_konfig/config.rb
+++ b/lib/app_konfig/config.rb
@@ -32,7 +32,7 @@ module AppKonfig
     private
 
     def pub_config
-      load_config(CONFIG_PATH[:public])
+      load_config(CONFIG_PATH[:public]) rescue {}
     end
 
     def sec_config

--- a/spec/app_konfig_spec.rb
+++ b/spec/app_konfig_spec.rb
@@ -78,6 +78,15 @@ RSpec.describe AppKonfig::Config do
     end
   end
 
+  context 'when config file is not found' do
+    it 'fails silently' do
+      stub_const('AppKonfig::Config::CONFIG_PATH', {
+        public: '',
+        secret: './config/secrets.yml',
+      })
+      expect{ subject }.not_to raise_error
+    end
+  end
 
   context 'when secrets file is not found' do
     it 'fails silently' do


### PR DESCRIPTION
I don't understand why the `secrets.yml` is optional and the `config.yml` is required.
In my situation I don't want any public config - I have only `secrets.yml` but I need to create dump `config.yml` with the keys for all envs. I think it should be possible to omit it.